### PR TITLE
delete staging definition

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,10 +76,3 @@ workflows:
             branches:
               only:
                 - master
-      - deploy-stg:
-          requires:
-            - build
-          filters:
-            branches:
-              only:
-                - dev


### PR DESCRIPTION
Staging環境の用意はやらない方針として、Stagingへデプロイを行うワークフロー定義を削除