### PR TITLE
:note: clearly stated commiter and auther

### DIFF
--- a/.github/workflows/check-vulnerability-weekly.yml
+++ b/.github/workflows/check-vulnerability-weekly.yml
@@ -36,9 +36,11 @@ jobs:
         npm audit fix
     - name: create pull-request
       if: failure()
-      uses: peter-evans/create-pull-request@v2
+      uses: peter-evans/create-pull-request@v3
       with:
-        token: ${{ secrets.GITUHB_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+        commiter: GitHub <noreply@github.com>
+        author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
         reviewers: nagashima-w, intercept6, TakumaNakagame
         title: fix vulnerability from GitHub Actions
         body: |


### PR DESCRIPTION
## 目的

- weeklyで実行している、npm auditでライブラリのアップデートがあった際にPRを作成するActionsのPR作成ユーザーの変更
  - いままでは@nagashima-w だったが、ブランチプロテクションを導入し、レビューなしのPRはマージできないように変更した結果、自動で作成されているPRであるにも関わらず@nagashima-w がひとりで確認してマージができなくなってしまった

## 変更内容

- 自動生成されるPRのcommiterとautherを明記した
- ついでに新しいversionがリリースされていたのでバージョンアップ

## 補足

$GITHUB_TOKENというsecretsについては[こちらのドキュメント](https://docs.github.com/ja/actions/configuring-and-managing-workflows/authenticating-with-the-github_token)に詳細がある